### PR TITLE
Remove patches-directory from gitignore (issue #4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@
 *.rej
 *.o
 dwm
-patches/
 dwm.pdf


### PR DESCRIPTION
By not ignoring the patches-directory people can see which patches are used. Now Luke only needs to push the patches-directory. See issue #4.