### PR TITLE
resizehints 0 to fix misaligned borders

### DIFF
--- a/config.h
+++ b/config.h
@@ -67,7 +67,7 @@ static const Rule rules[] = {
 /* layout(s) */
 static const float mfact     = 0.55; /* factor of master area size [0.05..0.95] */
 static const int nmaster     = 1;    /* number of clients in master area */
-static const int resizehints = 1;    /* 1 means respect size hints in tiled resizals */
+static const int resizehints = 0;    /* 1 means respect size hints in tiled resizals */
 
 #include "layouts.c"
 #include "fibonacci.c"


### PR DESCRIPTION
when resizing some windows with mod+l (like brave and discord next to each other)  windows don't get resized instead, they get moved offscreen because dwm is forced to respect resizehints, with 0 it respect's the borders screen and resize's the window regardless of the size of the app in it ... :)