### PR TITLE
some small modifications + highly recommended patches from bakkeby

### DIFF
--- a/config.h
+++ b/config.h
@@ -32,26 +32,6 @@ static const unsigned int alphas[][3]      = {
 
 static const char *tags[] = { "1", "2", "3", "4", "5", "6", "7", "8", "9" };
 
-/** Function to shift the current view to the left/right
- *
- * @param: "arg->i" stores the number of tags to shift right (positive value)
- *          or left (negative value)
- */
-void
-shiftview(const Arg *arg) {
-	Arg shifted;
-
-	if(arg->i > 0) // left circular shift
-		shifted.ui = (selmon->tagset[selmon->seltags] << arg->i)
-		   | (selmon->tagset[selmon->seltags] >> (LENGTH(tags) - arg->i));
-
-	else // right circular shift
-		shifted.ui = selmon->tagset[selmon->seltags] >> (- arg->i)
-		   | selmon->tagset[selmon->seltags] << (LENGTH(tags) + arg->i);
-
-	view(&shifted);
-}
-
 /* tagging */
 
 static const Rule rules[] = {

--- a/config.h
+++ b/config.h
@@ -30,9 +30,8 @@ static const unsigned int alphas[][3]      = {
 	[SchemeSel]  = { OPAQUE, baralpha, borderalpha },
 };
 
-static const char *tags[] = { "1", "2", "3", "4", "5", "6", "7", "8", "9" };
-
 /* tagging */
+static const char *tags[] = { "1", "2", "3", "4", "5", "6", "7", "8", "9" };
 
 static const Rule rules[] = {
 	/* xprop(1):
@@ -47,18 +46,18 @@ static const Rule rules[] = {
 /* layout(s) */
 static const float mfact     = 0.55; /* factor of master area size [0.05..0.95] */
 static const int nmaster     = 1;    /* number of clients in master area */
-static const int resizehints = 1;    /* 1 means respect size hints in tiled resizals */
+static const int resizehints = 0;    /* 1 means respect size hints in tiled resizals */
 
 #include "layouts.c"
 #include "fibonacci.c"
 static const Layout layouts[] = {
 	/* symbol     arrange function */
-	{ "[]=",	tile },    /* first entry is default */
-	{ "[M]",	monocle },
- 	{ "[@]",	spiral },
-	{ "|M|",	centeredmaster },
-	{ "><>",	NULL },    /* no layout function means floating behavior */
-	{ ">M>",	centeredfloatingmaster },
+	{ "[]=",      tile },    /* first entry is default */
+	{ "[M]",      monocle },
+ 	{ "[@]",      spiral },
+	{ "|M|",      centeredmaster },
+	{ "><>",      NULL },    /* no layout function means floating behavior */
+	{ ">M>",      centeredfloatingmaster },
 };
 
 /* key definitions */
@@ -78,64 +77,64 @@ static const char *dmenucmd[] = { "dmenu_run", "-m", dmenumon, "-fn", dmenufont,
 
 #include "movestack.c"
 static Key keys[] = {
-	/* modifier                     key        function        argument */
-	{ MODKEY,			XK_q,		killclient,	{0} },
-	{ MODKEY,                       XK_j,		focusstack,	{.i = +1 } },
-	{ MODKEY,                       XK_k,		focusstack,	{.i = -1 } },
-	{ MODKEY|ShiftMask,             XK_j,		movestack,	{.i = +1 } },
-	{ MODKEY|ShiftMask,             XK_k,		movestack,	{.i = -1 } },
-	{ MODKEY,			XK_space,	zoom,		{0} },
-	{ MODKEY,                       XK_h,		setmfact,	{.f = -0.05} },
-	{ MODKEY,                       XK_l,		setmfact,	{.f = +0.05} },
-	{ MODKEY|ShiftMask,		XK_i,		incnmaster,	{.i = +1 } },
-	{ MODKEY|ShiftMask,		XK_o,		incnmaster,	{.i = -1 } },
-	{ MODKEY,			XK_b,		togglebar,	{0} },
-	{ MODKEY,			XK_t,		setlayout,	{.v = &layouts[0]} },
-	{ MODKEY,			XK_f,		setlayout,	{.v = &layouts[1]} },
-	{ MODKEY,			XK_y,		setlayout,	{.v = &layouts[2]} },
-	{ MODKEY,			XK_u,		setlayout,	{.v = &layouts[3]} },
-	{ MODKEY,			XK_i,		setlayout,	{.v = &layouts[4]} },
-	{ MODKEY,			XK_o,		setlayout,	{.v = &layouts[5]} },
-	{ MODKEY,			XK_Tab,		view,		{0} },
-	{ MODKEY,			XK_backslash,	view,		{0} },
-	{ MODKEY|ShiftMask,		XK_space,	togglefloating,	{0} },
-	/* { MODKEY,                       XK_space,  setlayout,      {0} }, */
-	/* { MODKEY,                       XK_comma,  focusmon,       {.i = -1 } }, */
-	/* { MODKEY,                       XK_period, focusmon,       {.i = +1 } }, */
-	/* { MODKEY|ShiftMask,             XK_comma,  tagmon,         {.i = -1 } }, */
-	/* { MODKEY|ShiftMask,             XK_period, tagmon,         {.i = +1 } }, */
-	TAGKEYS(			XK_1,			0)
-	TAGKEYS(			XK_2,			1)
-	TAGKEYS(			XK_3,			2)
-	TAGKEYS(			XK_4,			3)
-	TAGKEYS(			XK_5,			4)
-	TAGKEYS(			XK_6,			5)
-	TAGKEYS(			XK_7,			6)
-	TAGKEYS(			XK_8,			7)
-	TAGKEYS(			XK_9,			8)
-	{ MODKEY,                       XK_0,		view,		{.ui = ~0 } },
-	{ MODKEY|ShiftMask,		XK_0,		tag,		{.ui = ~0 } },
-	{ MODKEY,			XK_F2,		quit,		{0} },
-	{ MODKEY,			XK_g,		shiftview,	{ .i = -1 } },
-	{ MODKEY,			XK_semicolon,	shiftview,	{ .i = 1 } },
-	{ MODKEY,			XK_Page_Up,	shiftview,	{ .i = -1 } },
-	{ MODKEY,			XK_Page_Down,	shiftview,	{ .i = 1 } },
-	/* { MODKEY|Mod4Mask,              XK_h,      incrgaps,       {.i = +1 } }, */
-	/* { MODKEY|Mod4Mask,              XK_l,      incrgaps,       {.i = -1 } }, */
-	{ MODKEY,    XK_z,      incrogaps,      {.i = +3 } },
-	{ MODKEY|ShiftMask,    XK_z,      incrogaps,      {.i = -3 } },
-	{ MODKEY,  XK_s,      incrigaps,      {.i = +3 } },
-	{ MODKEY|ShiftMask,  XK_s,      incrigaps,      {.i = -3 } },
-	{ MODKEY|ShiftMask,              XK_t,      defaultgaps,     {0} },
-	{ MODKEY|ShiftMask,    XK_d,      togglegaps,    {0} },
-	/* { MODKEY,                       XK_y,      incrihgaps,     {.i = +1 } }, */
-	/* { MODKEY,                       XK_o,      incrihgaps,     {.i = -1 } }, */
-	/* { MODKEY|ControlMask,           XK_y,      incrivgaps,     {.i = +1 } }, */
-	/* { MODKEY|ControlMask,           XK_o,      incrivgaps,     {.i = -1 } }, */
-	/* { MODKEY|Mod4Mask,              XK_y,      incrohgaps,     {.i = +1 } }, */
-	/* { MODKEY|Mod4Mask,              XK_o,      incrohgaps,     {.i = -1 } }, */
-	/* { MODKEY|ShiftMask,             XK_y,      incrovgaps,     {.i = +1 } }, */
-	/* { MODKEY|ShiftMask,             XK_o,      incrovgaps,     {.i = -1 } }, */
+	/* modifier                     key             function        argument */
+	{ MODKEY,                       XK_q,           killclient,     {0} },
+	{ MODKEY,                       XK_j,           focusstack,     {.i = +1 } },
+	{ MODKEY,                       XK_k,           focusstack,     {.i = -1 } },
+	{ MODKEY|ShiftMask,             XK_j,           movestack,      {.i = +1 } },
+	{ MODKEY|ShiftMask,             XK_k,           movestack,      {.i = -1 } },
+	{ MODKEY,                       XK_space,       zoom,           {0} },
+	{ MODKEY,                       XK_h,           setmfact,       {.f = -0.05} },
+	{ MODKEY,                       XK_l,           setmfact,       {.f = +0.05} },
+	{ MODKEY|ShiftMask,            	XK_i,           incnmaster,     {.i = +1 } },
+	{ MODKEY|ShiftMask,            	XK_o,           incnmaster,     {.i = -1 } },
+	{ MODKEY,                      	XK_b,           togglebar,      {0} },
+	{ MODKEY,                       XK_t,           setlayout,      {.v = &layouts[0]} },
+	{ MODKEY,                      	XK_f,           setlayout,      {.v = &layouts[1]} },
+	{ MODKEY,                      	XK_y,           setlayout,      {.v = &layouts[2]} },
+	{ MODKEY,                      	XK_u,           setlayout,      {.v = &layouts[3]} },
+	{ MODKEY,                      	XK_i,           setlayout,      {.v = &layouts[4]} },
+	{ MODKEY,                      	XK_o,           setlayout,      {.v = &layouts[5]} },
+	{ MODKEY,                      	XK_Tab,         view,           {0} },
+	{ MODKEY,                      	XK_backslash,   view,           {0} },
+	{ MODKEY|ShiftMask,             XK_space,       togglefloating,	{0} },
+	/* { MODKEY,                       XK_space,       setlayout,      {0} }, */
+	/* { MODKEY,                       XK_comma,       focusmon,       {.i = -1 } }, */
+	/* { MODKEY,                       XK_period,      focusmon,       {.i = +1 } }, */
+	/* { MODKEY|ShiftMask,             XK_comma,       tagmon,         {.i = -1 } }, */
+	/* { MODKEY|ShiftMask,             XK_period,      tagmon,         {.i = +1 } }, */
+	TAGKEYS(                        XK_1,                          	0)
+	TAGKEYS(                        XK_2,                          	1)
+	TAGKEYS(                        XK_3,                          	2)
+	TAGKEYS(                        XK_4,                          	3)
+	TAGKEYS(                        XK_5,                          	4)
+	TAGKEYS(                        XK_6,                          	5)
+	TAGKEYS(                        XK_7,                          	6)
+	TAGKEYS(                        XK_8,                          	7)
+	TAGKEYS(                        XK_9,                           8)
+	{ MODKEY,                       XK_0,           view,           {.ui = ~0 } },
+	{ MODKEY|ShiftMask,             XK_0,           tag,            {.ui = ~0 } },
+	{ MODKEY,                       XK_F2,          quit,           {0} },
+	{ MODKEY,                       XK_g,           shiftview,      { .i = -1 } },
+	{ MODKEY,                       XK_semicolon,   shiftview,      { .i = 1 } },
+	{ MODKEY,                       XK_Page_Up,     shiftview,      { .i = -1 } },
+	{ MODKEY,                       XK_Page_Down,   shiftview,      { .i = 1 } },
+	/* { MODKEY|Mod4Mask,              XK_h,           incrgaps,       {.i = +1 } }, */
+	/* { MODKEY|Mod4Mask,              XK_l,           incrgaps,       {.i = -1 } }, */
+	{ MODKEY,                       XK_z,           incrogaps,      {.i = +3 } },
+	{ MODKEY|ShiftMask,             XK_z,           incrogaps,      {.i = -3 } },
+	{ MODKEY,                       XK_s,           incrigaps,      {.i = +3 } },
+	{ MODKEY|ShiftMask,             XK_s,           incrigaps,      {.i = -3 } },
+	{ MODKEY|ShiftMask,             XK_t,           defaultgaps,    {0} },
+	{ MODKEY|ShiftMask,             XK_d,           togglegaps,     {0} },
+	/* { MODKEY,                       XK_y,           incrihgaps,     {.i = +1 } }, */
+	/* { MODKEY,                       XK_o,           incrihgaps,     {.i = -1 } }, */
+	/* { MODKEY|ControlMask,           XK_y,           incrivgaps,     {.i = +1 } }, */
+	/* { MODKEY|ControlMask,           XK_o,           incrivgaps,     {.i = -1 } }, */
+	/* { MODKEY|Mod4Mask,              XK_y,           incrohgaps,     {.i = +1 } }, */
+	/* { MODKEY|Mod4Mask,              XK_o,           incrohgaps,     {.i = -1 } }, */
+	/* { MODKEY|ShiftMask,             XK_y,           incrovgaps,     {.i = +1 } }, */
+	/* { MODKEY|ShiftMask,             XK_o,           incrovgaps,     {.i = -1 } }, */
 };
 
 /* button definitions */
@@ -154,4 +153,3 @@ static Button buttons[] = {
 	{ ClkTagBar,            MODKEY,         Button1,        tag,            {0} },
 	{ ClkTagBar,            MODKEY,         Button3,        toggletag,      {0} },
 };
-

--- a/dwm.c
+++ b/dwm.c
@@ -220,6 +220,7 @@ static void setmfact(const Arg *arg);
 static void setup(void);
 static void seturgent(Client *c, int urg);
 static void showhide(Client *c);
+static void shiftview(const Arg *arg);
 static void sigchld(int unused);
 static void spawn(const Arg *arg);
 static void tag(const Arg *arg);
@@ -1761,6 +1762,21 @@ showhide(Client *c)
 		showhide(c->snext);
 		XMoveWindow(dpy, c->win, WIDTH(c) * -2, c->y);
 	}
+}
+
+void
+shiftview(const Arg *arg) {
+	Arg shifted;
+
+	if(arg->i > 0) // left circular shift
+		shifted.ui = (selmon->tagset[selmon->seltags] << arg->i)
+		   | (selmon->tagset[selmon->seltags] >> (LENGTH(tags) - arg->i));
+
+	else // right circular shift
+		shifted.ui = selmon->tagset[selmon->seltags] >> (- arg->i)
+		   | selmon->tagset[selmon->seltags] << (LENGTH(tags) + arg->i);
+
+	view(&shifted);
 }
 
 void


### PR DESCRIPTION
1. shiftview is a function and it should be declared in dwm.c instead of config.h, so I removed it from config.h and applied the shiftview patch to dwm.c
2. changed resizehints to 0 as recommended on the vanitygaps patch, when at 1 some windows do not respect borders and overlap each other
3. realigned config.h to a more readable form :)