### PR TITLE
Fix libxft-bgra name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ This is suckless, mmmbud, the source code is the documentation! Check out `confi
 - gaps around windows and bar
 - dwmc
 
-## Please install `libxft-rbgra`!
+## Please install `libxft-bgra`!
 
-This build of dwm does not block color emoji in the status/info bar, so you must install [libxft-rbgra](https://aur.archlinux.org/packages/libxft-bgra/) from the AUR, which fixes a libxft color emoji rendering problem, otherwise dwm will crash upon trying to render one. Hopefully this fix will be in all libxft soon enough.
+This build of dwm does not block color emoji in the status/info bar, so you must install [libxft-bgra](https://aur.archlinux.org/packages/libxft-bgra/) from the AUR, which fixes a libxft color emoji rendering problem, otherwise dwm will crash upon trying to render one. Hopefully this fix will be in all libxft soon enough.


### PR DESCRIPTION
Fixed the name of the libxft-bgra package from libxft-rbgra.