### PR TITLE
Limit nmaster to the number of windows

### DIFF
--- a/dwm.c
+++ b/dwm.c
@@ -1015,7 +1015,10 @@ grabkeys(void)
 void
 incnmaster(const Arg *arg)
 {
-	selmon->nmaster = MAX(selmon->nmaster + arg->i, 0);
+	int n;
+	Client* c;
+	for(n = 0, c = nexttiled(selmon->clients); c; c = nexttiled(c->next), n++);
+	selmon->nmaster = TRUNC(selmon->nmaster + arg->i, 0, n);
 	arrange(selmon);
 }
 


### PR DESCRIPTION
Right now you can increase number of master windows beyond the number of windows. Holding Mod+o will increase nmaster without limit, for example to 100 when you hold it, and then you would need to hold Mod+O to decreases it. It seems weird/bugged so this fix limits the maximum value nmaster to the number of windows. I've tested it and it works for every layout(that uses nmaster). I just count how many windows are there and truncate if from above, so max nmaster is equal to number of windows.

I'll gladly explain more if there is a need.