### PR TITLE
small fix

### DIFF
--- a/config.h
+++ b/config.h
@@ -37,7 +37,7 @@ const char *spcmd2[] = {TERMINAL, "-n", "spcalc", "-f", "monospace:size=16", "-g
 static Sp scratchpads[] = {
 	/* name          cmd  */
 	{"spterm",      spcmd1},
-	{"spranger",    spcmd2},
+	{"spcalc",      spcmd2},
 };
 
 /* tagging */

--- a/config.h
+++ b/config.h
@@ -70,7 +70,7 @@ static const Layout layouts[] = {
 	{ "[@]",	spiral },		/* Fibonacci spiral */
 	{ "[\\]",	dwindle },		/* Decreasing in size right and leftward */
 
-	{ "H[]",	deck },			/* Master on left, slaves in monocle-like mode on right */
+	{ "[D]",	deck },			/* Master on left, slaves in monocle-like mode on right */
  	{ "[M]",	monocle },		/* All windows on top of eachother */
 
 	{ "|M|",	centeredmaster },		/* Master in middle, slaves on sides */


### PR DESCRIPTION
in your rules section, you have specified a rule for a scratchpad named spcalc, while in your scratchpad section the scratchpad that gives the calculator is named spranger, hence I assume the rules are not applied to the calculator... renamed spranger to spcalc to fix the issue... also changed the deck layout indicator to it's original [D] instead of M[], the deck layout indicator by original is [D], it appears  bakkeby made a typpo, or a intentional change when he made his vanitygaps patch, I find the H[] solution weird looking and it changes to D either way when you actually put something in to the deck, and that [D] works much better,  check it out and decide for ur self :) 