### PR TITLE
Add PKGBUILD and update Arch installation guide

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,47 @@
+_pkgname=dwm
+pkgname=$_pkgname-luke-git
+pkgver=6.2.r1888.0ac09e0
+pkgrel=1
+pkgdesc="Luke's build of dwm"
+url=https://github.com/LukeSmithxyz/dwm
+arch=(i686 x86_64)
+license=(MIT)
+makedepends=(git)
+depends=(freetype2 libx11 libxft)
+optdepends=(
+	'libxft-bgra: if dwm crashes when displaying emojis'
+	'libxft-bgra-git: if dwm crashes when displaying emojis'
+	'dmenu: program launcher'
+	'st: terminal emulator')
+provides=($_pkgname)
+conflicts=($_pkgname)
+source=(git+https://github.com/LukeSmithxyz/dwm)
+sha256sums=('SKIP')
+
+pkgver() {
+	cd "$_pkgname"
+	echo "$(awk '/^VERSION =/ {print $3}' config.mk)".r"$(git rev-list --count HEAD)"."$(git rev-parse --short HEAD)"
+}
+
+prepare() {
+	cd "$_pkgname"
+	echo "CPPFLAGS+=${CPPFLAGS}" >> config.mk
+	echo "CFLAGS+=${CFLAGS}" >> config.mk
+	echo "LDFLAGS+=${LDFLAGS}" >> config.mk
+	# to use a custom config.h, place it in the package directory
+	if [[ -f ${SRCDEST}/config.h ]]; then
+		cp "${SRCDEST}/config.h" .
+	fi
+}
+
+build() {
+	cd "$_pkgname"
+	make X11INC=/usr/include/X11 X11LIB=/usr/lib/X11
+}
+
+package() {
+	cd "$_pkgname"
+	make PREFIX=/usr DESTDIR="$pkgdir" install
+	install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}
+# vim:set ts=4 sw=4 noet:

--- a/README.md
+++ b/README.md
@@ -23,10 +23,39 @@ I haven't kept `man dwm`/`dwm.1` updated though. PRs welcome on that, lol.
 - [vanitygaps](https://dwm.suckless.org/patches/vanitygaps/): Gaps allowed across all layouts.
 - [swallow patch](https://dwm.suckless.org/patches/swallow/): if a program run from a terminal would make it inoperable, it temporarily takes its place to save space.
 
+## Installation on Arch Linux based distributions
+
+### Download the source code
+
+```bash
+git clone https://github.com/LukeSmithxyz/dwm.git
+cd dwm
+```
+
+### Configure
+
+To use a custom `config.h`, place it in the package directory.
+
+### Compile and install
+
+To compile dwm you need to install the `base-devel` package group if you haven't done it previously.
+
+If you have `paru` installed:
+
+```bash
+paru -Ui
+```
+
+Otherwise:
+
+```bash
+makepkg -cirs
+```
+
 ## Installation for newbs
 
-```
-git clone https://github.com/LukeSmithxyz/dwm
+```bash
+git clone https://github.com/LukeSmithxyz/dwm.git
 cd dwm
 sudo make install
 ```


### PR DESCRIPTION
I was the maintainer of the dwm-luke-git AUR package.
The package was removed from the AUR by the AUR Team because, as they think, it was `Specifically tailored for one person`.