### PR TITLE
README: add `fonts-symbola` package for ubuntu users

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,5 @@ sudo make install
 ## Please install `libxft-bgra`!
 
 This build of dwm does not block color emoji in the status/info bar, so you must install [libxft-bgra](https://aur.archlinux.org/packages/libxft-bgra/) from the AUR, which fixes a libxft color emoji rendering problem, otherwise dwm will crash upon trying to render one. Hopefully this fix will be in all libxft soon enough.
+
+Also, if you are Ubuntu user make sure to install `fonts-symbola` instead of `libxft-bgra`.


### PR DESCRIPTION
So many people asking about how to fix this problem for Ubuntu users, Google: `libxft-bgra ubuntu`
so, I think it will be useful if we added an alternative method for them.