### PR TITLE
Unset fullscreen mode for current window when new window is opened

### DIFF
--- a/dwm.c
+++ b/dwm.c
@@ -1248,6 +1248,8 @@ manage(Window w, XWindowAttributes *wa)
 		(unsigned char *) &(c->win), 1);
 	XMoveResizeWindow(dpy, c->win, c->x + 2 * sw, c->y, c->w, c->h); /* some windows require this */
 	setclientstate(c, NormalState);
+	if(selmon->sel && selmon->sel->isfullscreen && !c->isfloating)
+		setfullscreen(selmon->sel, 0);
 	if (c->mon == selmon)
 		unfocus(selmon->sel, 0);
 	c->mon->sel = c;


### PR DESCRIPTION
As it is now when current windows is set to fullscreen mode, and you open a new window, for example by pressing Super-Enter fullscreen window stays on top, but focus moves to the newly opened window, which may even not be visible if the current fullscreened window is opaque.
I find that behavior very confusing. This pull request is fixing that by first unsetting fullscreen mode on the current window.