### PR TITLE
Autostart/run script

### DIFF
--- a/dwm.c
+++ b/dwm.c
@@ -1591,6 +1591,7 @@ run(void)
 void
 runAutostart(void) {
 	system("killall -q dwmblocks; dwmblocks &");
+	system("cd ~/.dwm; ./autostart.sh &");
 }
 
 void


### PR DESCRIPTION
This runs a script at  `~/.dwm/autostart.sh` when booted

This allows for easy configuration for example turning numlock on or running a script you made yourself that fixes a problem.
