### PR TITLE
(README.md) put keyboard shortcuts in <kbd> tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,19 @@
 This is suckless, mmmbud, the source code is the documentation! Check out [config.h](config.h).
 
 Okay, okay, actually I keep a readme in `larbs.mom` for my whole system, including the binds here.
-Press `super+F1` to view it in dwm (zathura is required for that binding).
+Press <kbd>super+F1</kbd> to view it in dwm (zathura is required for that binding).
 I haven't kept `man dwm`/`dwm.1` updated though. PRs welcome on that, lol.
 
 ## Patches and features
 
 - [Clickable statusbar](https://dwm.suckless.org/patches/statuscmd/) with my build of [dwmblocks](https://github.com/lukesmithxyz/dwmblocks).
 - Reads [xresources](https://dwm.suckless.org/patches/xresources/) colors/variables (i.e. works with `pywal`, etc.).
-- scratchpad: Accessible with mod+shift+enter.
-- New layouts: bstack, fibonacci, deck, centered master and more. All bound to keys `super+(shift+)t/y/u/i`.
-- True fullscreen (`super+f`) and prevents focus shifting.
-- Windows can be made sticky (`super+s`).
-- [stacker](https://dwm.suckless.org/patches/stacker/): Move windows up the stack manually (`super-K/J`).
-- [shiftview](https://dwm.suckless.org/patches/nextprev/): Cycle through tags (`super+g/;`).
+- scratchpad: Accessible with <kbd>mod+shift+enter</kbd>.
+- New layouts: bstack, fibonacci, deck, centered master and more. All bound to keys <kbd>super+(shift+)t/y/u/i</kbd>.
+- True fullscreen (<kbd>super+f</kbd>) and prevents focus shifting.
+- Windows can be made sticky (<kbd>super+s</kbd>).
+- [stacker](https://dwm.suckless.org/patches/stacker/): Move windows up the stack manually (<kbd>super-K/J</kbd>).
+- [shiftview](https://dwm.suckless.org/patches/nextprev/): Cycle through tags (<kbd>super+g/;</kbd>).
 - [vanitygaps](https://dwm.suckless.org/patches/vanitygaps/): Gaps allowed across all layouts.
 - [swallow patch](https://dwm.suckless.org/patches/swallow/): if a program run from a terminal would make it inoperable, it temporarily takes its place to save space.
 


### PR DESCRIPTION
Helps distinguish them from other commands/files in the README
Also fixed scratchpad's shortcut (mod+shift+enter) being unformatted

Surrounded in `` ` ``:
All bound to keys `super+(shift+)t/y/u/i`.
Surrounded in `<kbd>`:
All bound to keys <kbd>super+(shift+)t/y/u/i</kbd>.