### PR TITLE
Switching to libxft-git

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -9,8 +9,7 @@ license=(MIT)
 makedepends=(git)
 depends=(freetype2 libx11 libxft)
 optdepends=(
-	'libxft-bgra: if dwm crashes when displaying emojis'
-	'libxft-bgra-git: if dwm crashes when displaying emojis'
+	'libxft-git: if dwm crashes when displaying emojis'
 	'dmenu: program launcher'
 	'st: terminal emulator')
 provides=($_pkgname)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,6 @@ sudo make install
 
 There is also a `PKGBUILD` usable on distributions with pacman. Run `makepkg -si` instead of `sudo make install`.
 
-### You must also install `libxft-bgra`!
+### You must also install `libxft-git`!
 
-This build of dwm does not block color emoji in the status/info bar, so you must install [libxft-bgra](https://aur.archlinux.org/packages/libxft-bgra/), which fixes a libxft color emoji rendering problem, otherwise dwm will crash upon trying to render one. Hopefully this fix will be in all libxft soon enough.
+This build of dwm does not block color emoji in the status/info bar, so you must install [libxft-git](https://aur.archlinux.org/packages/libxft-git/), which fixes a libxft color emoji rendering problem, otherwise dwm will crash upon trying to render one. Hopefully this fix will be in all libxft soon enough.

--- a/dwm.1
+++ b/dwm.1
@@ -27,12 +27,12 @@ indicated with an empty square in the top left corner.
 dwm draws a small border around windows to indicate the focus state.
 .P
 .I
-libxft-bgra
+libxft-git
 should be installed for this build of dwm. Arch users may install it via the
 AUR. Color characters and emoji are enabled, but these will cause crashes
 without the fix
 .I
-libxft-bgra
+libxft-git
 offers.
 .SH OPTIONS
 .TP


### PR DESCRIPTION
`libxft-bgra` is not in the AUR anymore.