### PR TITLE
Align Format & Fix Clang Warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
 .gitignore
+*.o
 *.orig
 *.rej
+dwm
 larbs.pdf
 patches
-util.o
-dwm
-dwm.o
-drw.o

--- a/config.h
+++ b/config.h
@@ -16,7 +16,7 @@ static int swallowfloating    = 0;        /* 1 means swallow floating windows by
 static int smartgaps          = 0;        /* 1 means no outer gap when there is only one window */
 static int showbar            = 1;        /* 0 means no bar */
 static int topbar             = 1;        /* 0 means bottom bar */
-static char *fonts[]          = { "monospace:size=10", "NotoColorEmoji:pixelsize=10:antialias=true:autohint=true"  };
+static char *fonts[]          = { "monospace:size=10", "NotoColorEmoji:pixelsize=10:antialias=true:autohint=true" };
 static char normbgcolor[]           = "#222222";
 static char normbordercolor[]       = "#444444";
 static char normfgcolor[]           = "#bbbbbb";
@@ -24,9 +24,9 @@ static char selfgcolor[]            = "#eeeeee";
 static char selbordercolor[]        = "#770000";
 static char selbgcolor[]            = "#005577";
 static char *colors[][3] = {
-       /*               fg           bg           border   */
-       [SchemeNorm] = { normfgcolor, normbgcolor, normbordercolor },
-       [SchemeSel]  = { selfgcolor,  selbgcolor,  selbordercolor  },
+	/*               fg           bg           border   */
+	[SchemeNorm] = { normfgcolor, normbgcolor, normbordercolor },
+	[SchemeSel]  = { selfgcolor,  selbgcolor,  selbordercolor  },
 };
 
 typedef struct {
@@ -49,14 +49,14 @@ static const Rule rules[] = {
 	 *	WM_CLASS(STRING) = instance, class
 	 *	WM_NAME(STRING) = title
 	*/
-	/* class    instance      title       	 tags mask    isfloating   isterminal  noswallow  monitor */
-	{ "Gimp",     NULL,       NULL,          1 << 8,      0,           0,          0,         -1 },
-	{ TERMCLASS,  NULL,       NULL,       	 0,           0,           1,          0,         -1 },
-	{ NULL,       NULL,       "Event Tester", 0,          0,           0,          1,         -1 },
-	{ TERMCLASS,  "floatterm", NULL,       	 0,           1,           1,          0,         -1 },
-	{ TERMCLASS,  "bg",        NULL,       	 1 << 7,      0,           1,          0,         -1 },
-	{ TERMCLASS,  "spterm",    NULL,       	 SPTAG(0),    1,           1,          0,         -1 },
-	{ TERMCLASS,  "spcalc",    NULL,       	 SPTAG(1),    1,           1,          0,         -1 },
+	/* class      instance     title          tags mask    isfloating   isterminal  noswallow  monitor */
+	{ "Gimp",     NULL,        NULL,          1 << 8,      0,           0,          0,         -1 },
+	{ TERMCLASS,  NULL,        NULL,          0,           0,           1,          0,         -1 },
+	{ NULL,       NULL,       "Event Tester", 0,           0,           0,          1,         -1 },
+	{ TERMCLASS,  "floatterm", NULL,          0,           1,           1,          0,         -1 },
+	{ TERMCLASS,  "bg",        NULL,          1 << 7,      0,           1,          0,         -1 },
+	{ TERMCLASS,  "spterm",    NULL,          SPTAG(0),    1,           1,          0,         -1 },
+	{ TERMCLASS,  "spcalc",    NULL,          SPTAG(1),    1,           1,          0,         -1 },
 };
 
 /* layout(s) */
@@ -68,20 +68,16 @@ static const int lockfullscreen = 1; /* 1 will force focus on the fullscreen win
 #include "vanitygaps.c"
 static const Layout layouts[] = {
 	/* symbol     arrange function */
-	{ "[]=",	tile },	                /* Default: Master on left, slaves on right */
-	{ "TTT",	bstack },               /* Master on top, slaves on bottom */
-
-	{ "[@]",	spiral },               /* Fibonacci spiral */
-	{ "[\\]",	dwindle },              /* Decreasing in size right and leftward */
-
-	{ "[D]",	deck },	                /* Master on left, slaves in monocle-like mode on right */
-	{ "[M]",	monocle },              /* All windows on top of eachother */
-
-	{ "|M|",	centeredmaster },               /* Master in middle, slaves on sides */
-	{ ">M>",	centeredfloatingmaster },       /* Same but master floats */
-
-	{ "><>",	NULL },	                /* no layout function means floating behavior */
-	{ NULL,		NULL },
+	{ "[]=",  tile },                         /* Default: Master on left, slaves on right */
+	{ "TTT",  bstack },                       /* Master on top, slaves on bottom */
+	{ "[@]",  spiral },                       /* Fibonacci spiral */
+	{ "[\\]", dwindle },                      /* Decreasing in size right and leftward */
+	{ "[D]",  deck },                         /* Master on left, slaves in monocle-like mode on right */
+	{ "[M]",  monocle },                      /* All windows on top of eachother */
+	{ "|M|",  centeredmaster },               /* Master in middle, slaves on sides */
+	{ ">M>",  centeredfloatingmaster },       /* Same but master floats */
+	{ "><>",  NULL },                         /* no layout function means floating behavior */
+	{ NULL,   NULL },
 };
 
 /* key definitions */
@@ -92,16 +88,17 @@ static const Layout layouts[] = {
 	{ MODKEY|ShiftMask,             KEY,      tag,            {.ui = 1 << TAG} }, \
 	{ MODKEY|ControlMask|ShiftMask, KEY,      toggletag,      {.ui = 1 << TAG} },
 #define STACKKEYS(MOD,ACTION) \
-	{ MOD,	XK_j,	ACTION##stack,	{.i = INC(+1) } }, \
-	{ MOD,	XK_k,	ACTION##stack,	{.i = INC(-1) } }, \
-	{ MOD,  XK_v,   ACTION##stack,  {.i = 0 } }, \
+	{ MOD,  XK_j, ACTION##stack,  {.i = INC(+1) } }, \
+	{ MOD,  XK_k, ACTION##stack,  {.i = INC(-1) } }, \
+	{ MOD,  XK_v, ACTION##stack,  {.i = 0 } }, \
 	/* { MOD, XK_grave, ACTION##stack, {.i = PREVSEL } }, \ */
 	/* { MOD, XK_a,     ACTION##stack, {.i = 1 } }, \ */
 	/* { MOD, XK_z,     ACTION##stack, {.i = 2 } }, \ */
 	/* { MOD, XK_x,     ACTION##stack, {.i = -1 } }, */
 
-/* helper for spawning shell commands in the pre dwm-5.0 fashion */
+/* Helper macros for spawning commands */
 #define SHCMD(cmd) { .v = (const char*[]){ "/bin/sh", "-c", cmd, NULL } }
+#define CMD(...)   { .v = (const char*[]){ __VA_ARGS__, NULL } }
 
 /* commands */
 static const char *termcmd[]  = { TERMINAL, NULL };
@@ -110,25 +107,25 @@ static const char *termcmd[]  = { TERMINAL, NULL };
  * Xresources preferences to load at startup
  */
 ResourcePref resources[] = {
-		{ "color0",		STRING,	&normbordercolor },
-		{ "color8",		STRING,	&selbordercolor },
-		{ "color0",		STRING,	&normbgcolor },
-		{ "color4",		STRING,	&normfgcolor },
-		{ "color0",		STRING,	&selfgcolor },
-		{ "color4",		STRING,	&selbgcolor },
-		{ "borderpx",		INTEGER, &borderpx },
-		{ "snap",		INTEGER, &snap },
-		{ "showbar",		INTEGER, &showbar },
-		{ "topbar",		INTEGER, &topbar },
-		{ "nmaster",		INTEGER, &nmaster },
-		{ "resizehints",	INTEGER, &resizehints },
-		{ "mfact",		FLOAT,	&mfact },
-		{ "gappih",		INTEGER, &gappih },
-		{ "gappiv",		INTEGER, &gappiv },
-		{ "gappoh",		INTEGER, &gappoh },
-		{ "gappov",		INTEGER, &gappov },
-		{ "swallowfloating",	INTEGER, &swallowfloating },
-		{ "smartgaps",		INTEGER, &smartgaps },
+		{ "color0",          STRING,  &normbordercolor },
+		{ "color8",          STRING,  &selbordercolor },
+		{ "color0",          STRING,  &normbgcolor },
+		{ "color4",          STRING,  &normfgcolor },
+		{ "color0",          STRING,  &selfgcolor },
+		{ "color4",          STRING,  &selbgcolor },
+		{ "borderpx",        INTEGER, &borderpx },
+		{ "snap",            INTEGER, &snap },
+		{ "showbar",         INTEGER, &showbar },
+		{ "topbar",          INTEGER, &topbar },
+		{ "nmaster",         INTEGER, &nmaster },
+		{ "resizehints",     INTEGER, &resizehints },
+		{ "mfact",           FLOAT,   &mfact },
+		{ "gappih",          INTEGER, &gappih },
+		{ "gappiv",          INTEGER, &gappiv },
+		{ "gappoh",          INTEGER, &gappoh },
+		{ "gappov",          INTEGER, &gappov },
+		{ "swallowfloating", INTEGER, &swallowfloating },
+		{ "smartgaps",       INTEGER, &smartgaps },
 };
 
 #include <X11/XF86keysym.h>
@@ -138,127 +135,127 @@ static const Key keys[] = {
 	/* modifier                     key            function                argument */
 	STACKKEYS(MODKEY,                              focus)
 	STACKKEYS(MODKEY|ShiftMask,                    push)
-	/* { MODKEY|ShiftMask,		XK_Escape,     spawn,	               SHCMD("") }, */
-	{ MODKEY,			XK_grave,      spawn,	               {.v = (const char*[]){ "dmenuunicode", NULL } } },
-	/* { MODKEY|ShiftMask,		XK_grave,      togglescratch,	       SHCMD("") }, */
-	TAGKEYS(			XK_1,          0)
-	TAGKEYS(			XK_2,          1)
-	TAGKEYS(			XK_3,          2)
-	TAGKEYS(			XK_4,          3)
-	TAGKEYS(			XK_5,          4)
-	TAGKEYS(			XK_6,          5)
-	TAGKEYS(			XK_7,          6)
-	TAGKEYS(			XK_8,          7)
-	TAGKEYS(			XK_9,          8)
-	{ MODKEY,			XK_0,	       view,                   {.ui = ~0 } },
-	{ MODKEY|ShiftMask,		XK_0,	       tag,                    {.ui = ~0 } },
-	{ MODKEY,			XK_minus,      spawn,                  SHCMD("wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-; kill -44 $(pidof dwmblocks)") },
-	{ MODKEY|ShiftMask,		XK_minus,      spawn,                  SHCMD("wpctl set-volume @DEFAULT_AUDIO_SINK@ 15%-; kill -44 $(pidof dwmblocks)") },
-	{ MODKEY,			XK_equal,      spawn,                  SHCMD("wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%+; kill -44 $(pidof dwmblocks)") },
-	{ MODKEY|ShiftMask,		XK_equal,      spawn,                  SHCMD("wpctl set-volume @DEFAULT_AUDIO_SINK@ 15%+; kill -44 $(pidof dwmblocks)") },
-	{ MODKEY,			XK_BackSpace,  spawn,                  {.v = (const char*[]){ "sysact", NULL } } },
-	{ MODKEY|ShiftMask,		XK_BackSpace,  spawn,                  {.v = (const char*[]){ "sysact", NULL } } },
+	/* { MODKEY|ShiftMask,             XK_Escape,     spawn,                  SHCMD("") }, */
+	{ MODKEY,                       XK_grave,      spawn,                  {.v = (const char*[]){ "dmenuunicode", NULL } } },
+	/* { MODKEY|ShiftMask,             XK_grave,      togglescratch,          SHCMD("") }, */
+	TAGKEYS(                        XK_1,          0)
+	TAGKEYS(                        XK_2,          1)
+	TAGKEYS(                        XK_3,          2)
+	TAGKEYS(                        XK_4,          3)
+	TAGKEYS(                        XK_5,          4)
+	TAGKEYS(                        XK_6,          5)
+	TAGKEYS(                        XK_7,          6)
+	TAGKEYS(                        XK_8,          7)
+	TAGKEYS(                        XK_9,          8)
+	{ MODKEY,                       XK_0,          view,                   {.ui = ~0 } },
+	{ MODKEY|ShiftMask,             XK_0,          tag,                    {.ui = ~0 } },
+	{ MODKEY,                       XK_minus,      spawn,                  SHCMD("wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-; kill -44 $(pidof dwmblocks)") },
+	{ MODKEY|ShiftMask,             XK_minus,      spawn,                  SHCMD("wpctl set-volume @DEFAULT_AUDIO_SINK@ 15%-; kill -44 $(pidof dwmblocks)") },
+	{ MODKEY,                       XK_equal,      spawn,                  SHCMD("wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%+; kill -44 $(pidof dwmblocks)") },
+	{ MODKEY|ShiftMask,             XK_equal,      spawn,                  SHCMD("wpctl set-volume @DEFAULT_AUDIO_SINK@ 15%+; kill -44 $(pidof dwmblocks)") },
+	{ MODKEY,                       XK_BackSpace,  spawn,                  {.v = (const char*[]){ "sysact", NULL } } },
+	{ MODKEY|ShiftMask,             XK_BackSpace,  spawn,                  {.v = (const char*[]){ "sysact", NULL } } },
 
-	{ MODKEY,			XK_Tab,        view,                   {0} },
-	/* { MODKEY|ShiftMask,		XK_Tab,	       spawn,                  SHCMD("") }, */
-	{ MODKEY,			XK_q,          killclient,             {0} },
-	{ MODKEY|ShiftMask,		XK_q,          spawn,                  {.v = (const char*[]){ "sysact", NULL } } },
-	{ MODKEY,			XK_w,          spawn,                  {.v = (const char*[]){ BROWSER, NULL } } },
-	{ MODKEY|ShiftMask,		XK_w,          spawn,                  {.v = (const char*[]){ TERMINAL, "-e", "sudo", "nmtui", NULL } } },
-	{ MODKEY,			XK_e,          spawn,                  SHCMD(TERMINAL " -e neomutt ; pkill -RTMIN+12 dwmblocks; rmdir ~/.abook 2>/dev/null") },
-	{ MODKEY|ShiftMask,		XK_e,          spawn,                  SHCMD(TERMINAL " -e abook -C ~/.config/abook/abookrc --datafile ~/.config/abook/addressbook") },
-	{ MODKEY,			XK_r,          spawn,                  {.v = (const char*[]){ TERMINAL, "-e", "lfub", NULL } } },
-	{ MODKEY|ShiftMask,		XK_r,          spawn,                  {.v = (const char*[]){ TERMINAL, "-e", "htop", NULL } } },
-	{ MODKEY,			XK_t,          setlayout,              {.v = &layouts[0]} }, /* tile */
-	{ MODKEY|ShiftMask,		XK_t,          setlayout,              {.v = &layouts[1]} }, /* bstack */
-	{ MODKEY,			XK_y,          setlayout,              {.v = &layouts[2]} }, /* spiral */
-	{ MODKEY|ShiftMask,		XK_y,          setlayout,              {.v = &layouts[3]} }, /* dwindle */
-	{ MODKEY,			XK_u,          setlayout,              {.v = &layouts[4]} }, /* deck */
-	{ MODKEY|ShiftMask,		XK_u,          setlayout,              {.v = &layouts[5]} }, /* monocle */
-	{ MODKEY,			XK_i,          setlayout,              {.v = &layouts[6]} }, /* centeredmaster */
-	{ MODKEY|ShiftMask,		XK_i,          setlayout,              {.v = &layouts[7]} }, /* centeredfloatingmaster */
-	{ MODKEY,			XK_o,          incnmaster,             {.i = +1 } },
-	{ MODKEY|ShiftMask,		XK_o,          incnmaster,             {.i = -1 } },
-	{ MODKEY,			XK_p,          spawn,                  {.v = (const char*[]){ "mpc", "toggle", NULL } } },
-	{ MODKEY|ShiftMask,		XK_p,          spawn,                  SHCMD("mpc pause; pauseallmpv") },
-	{ MODKEY,			XK_bracketleft, spawn,                 {.v = (const char*[]){ "mpc", "seek", "-10", NULL } } },
-	{ MODKEY|ShiftMask,		XK_bracketleft, spawn,                 {.v = (const char*[]){ "mpc", "seek", "-60", NULL } } },
-	{ MODKEY,			XK_bracketright, spawn,                {.v = (const char*[]){ "mpc", "seek", "+10", NULL } } },
-	{ MODKEY|ShiftMask,		XK_bracketright, spawn,                {.v = (const char*[]){ "mpc", "seek", "+60", NULL } } },
-	{ MODKEY,			XK_backslash,  view,                   {0} },
-	/* { MODKEY|ShiftMask,		XK_backslash,  spawn,                  SHCMD("") }, */
+	{ MODKEY,                       XK_Tab,        view,                   {0} },
+	/* { MODKEY|ShiftMask,             XK_Tab,        spawn,                  SHCMD("") }, */
+	{ MODKEY,                       XK_q,          killclient,             {0} },
+	{ MODKEY|ShiftMask,             XK_q,          spawn,                  {.v = (const char*[]){ "sysact", NULL } } },
+	{ MODKEY,                       XK_w,          spawn,                  {.v = (const char*[]){ BROWSER, NULL } } },
+	{ MODKEY|ShiftMask,             XK_w,          spawn,                  {.v = (const char*[]){ TERMINAL, "-e", "sudo", "nmtui", NULL } } },
+	{ MODKEY,                       XK_e,          spawn,                  SHCMD(TERMINAL " -e neomutt ; pkill -RTMIN+12 dwmblocks; rmdir ~/.abook 2>/dev/null") },
+	{ MODKEY|ShiftMask,             XK_e,          spawn,                  SHCMD(TERMINAL " -e abook -C ~/.config/abook/abookrc --datafile ~/.config/abook/addressbook") },
+	{ MODKEY,                       XK_r,          spawn,                  {.v = (const char*[]){ TERMINAL, "-e", "lfub", NULL } } },
+	{ MODKEY|ShiftMask,             XK_r,          spawn,                  {.v = (const char*[]){ TERMINAL, "-e", "htop", NULL } } },
+	{ MODKEY,                       XK_t,          setlayout,              {.v = &layouts[0]} }, /* tile */
+	{ MODKEY|ShiftMask,             XK_t,          setlayout,              {.v = &layouts[1]} }, /* bstack */
+	{ MODKEY,                       XK_y,          setlayout,              {.v = &layouts[2]} }, /* spiral */
+	{ MODKEY|ShiftMask,             XK_y,          setlayout,              {.v = &layouts[3]} }, /* dwindle */
+	{ MODKEY,                       XK_u,          setlayout,              {.v = &layouts[4]} }, /* deck */
+	{ MODKEY|ShiftMask,             XK_u,          setlayout,              {.v = &layouts[5]} }, /* monocle */
+	{ MODKEY,                       XK_i,          setlayout,              {.v = &layouts[6]} }, /* centeredmaster */
+	{ MODKEY|ShiftMask,             XK_i,          setlayout,              {.v = &layouts[7]} }, /* centeredfloatingmaster */
+	{ MODKEY,                       XK_o,          incnmaster,             {.i = +1 } },
+	{ MODKEY|ShiftMask,             XK_o,          incnmaster,             {.i = -1 } },
+	{ MODKEY,                       XK_p,          spawn,                  {.v = (const char*[]){ "mpc", "toggle", NULL } } },
+	{ MODKEY|ShiftMask,             XK_p,          spawn,                  SHCMD("mpc pause; pauseallmpv") },
+	{ MODKEY,                       XK_bracketleft, spawn,                 {.v = (const char*[]){ "mpc", "seek", "-10", NULL } } },
+	{ MODKEY|ShiftMask,             XK_bracketleft, spawn,                 {.v = (const char*[]){ "mpc", "seek", "-60", NULL } } },
+	{ MODKEY,                       XK_bracketright, spawn,                {.v = (const char*[]){ "mpc", "seek", "+10", NULL } } },
+	{ MODKEY|ShiftMask,             XK_bracketright, spawn,                {.v = (const char*[]){ "mpc", "seek", "+60", NULL } } },
+	{ MODKEY,                       XK_backslash,  view,                   {0} },
+	/* { MODKEY|ShiftMask,             XK_backslash,  spawn,                  SHCMD("") }, */
 
-	{ MODKEY,			XK_a,          togglegaps,             {0} },
-	{ MODKEY|ShiftMask,		XK_a,          defaultgaps,            {0} },
-	{ MODKEY,			XK_s,          togglesticky,           {0} },
-	/* { MODKEY|ShiftMask,		XK_s,          spawn,                  SHCMD("") }, */
-	{ MODKEY,			XK_d,          spawn,                  {.v = (const char*[]){ "dmenu_run", NULL } } },
-	{ MODKEY|ShiftMask,		XK_d,          spawn,                  {.v = (const char*[]){ "passmenu", NULL } } },
-	{ MODKEY,			XK_f,          togglefullscr,          {0} },
-	{ MODKEY|ShiftMask,		XK_f,          setlayout,              {.v = &layouts[8]} },
-	{ MODKEY,			XK_g,          shiftview,              { .i = -1 } },
-	{ MODKEY|ShiftMask,		XK_g,          shifttag,               { .i = -1 } },
-	{ MODKEY,			XK_h,          setmfact,               {.f = -0.05} },
+	{ MODKEY,                       XK_a,          togglegaps,             {0} },
+	{ MODKEY|ShiftMask,             XK_a,          defaultgaps,            {0} },
+	{ MODKEY,                       XK_s,          togglesticky,           {0} },
+	/* { MODKEY|ShiftMask,             XK_s,          spawn,                  SHCMD("") }, */
+	{ MODKEY,                       XK_d,          spawn,                  {.v = (const char*[]){ "dmenu_run", NULL } } },
+	{ MODKEY|ShiftMask,             XK_d,          spawn,                  {.v = (const char*[]){ "passmenu", NULL } } },
+	{ MODKEY,                       XK_f,          togglefullscr,          {0} },
+	{ MODKEY|ShiftMask,             XK_f,          setlayout,              {.v = &layouts[8]} },
+	{ MODKEY,                       XK_g,          shiftview,              { .i = -1 } },
+	{ MODKEY|ShiftMask,             XK_g,          shifttag,               { .i = -1 } },
+	{ MODKEY,                       XK_h,          setmfact,               {.f = -0.05} },
 	/* J and K are automatically bound above in STACKEYS */
-	{ MODKEY,			XK_l,          setmfact,               {.f = +0.05} },
-	{ MODKEY,			XK_semicolon,  shiftview,              { .i = 1 } },
-	{ MODKEY|ShiftMask,		XK_semicolon,  shifttag,               { .i = 1 } },
-	{ MODKEY,			XK_apostrophe, togglescratch,          {.ui = 1} },
-	/* { MODKEY|ShiftMask,		XK_apostrophe, spawn,                  SHCMD("") }, */
-	{ MODKEY|ShiftMask,		XK_apostrophe, togglesmartgaps,        {0} },
-	{ MODKEY,			XK_Return,     spawn,                  {.v = termcmd } },
-	{ MODKEY|ShiftMask,		XK_Return,     togglescratch,          {.ui = 0} },
+	{ MODKEY,                       XK_l,          setmfact,               {.f = +0.05} },
+	{ MODKEY,                       XK_semicolon,  shiftview,              { .i = 1 } },
+	{ MODKEY|ShiftMask,             XK_semicolon,  shifttag,               { .i = 1 } },
+	{ MODKEY,                       XK_apostrophe, togglescratch,          {.ui = 1} },
+	/* { MODKEY|ShiftMask,             XK_apostrophe, spawn,                  SHCMD("") }, */
+	{ MODKEY|ShiftMask,             XK_apostrophe, togglesmartgaps,        {0} },
+	{ MODKEY,                       XK_Return,     spawn,                  {.v = termcmd } },
+	{ MODKEY|ShiftMask,             XK_Return,     togglescratch,          {.ui = 0} },
 
-	{ MODKEY,			XK_z,          incrgaps,               {.i = +3 } },
-	/* { MODKEY|ShiftMask,		XK_z,          spawn,                  SHCMD("") }, */
-	{ MODKEY,			XK_x,          incrgaps,               {.i = -3 } },
-	/* { MODKEY|ShiftMask,		XK_x,          spawn,                  SHCMD("") }, */
-	{ MODKEY,			XK_c,          spawn,                  {.v = (const char*[]){ TERMINAL, "-e", "profanity", NULL } } },
-	/* { MODKEY|ShiftMask,		XK_c,          spawn,                  SHCMD("") }, */
+	{ MODKEY,                       XK_z,          incrgaps,               {.i = +3 } },
+	/* { MODKEY|ShiftMask,             XK_z,          spawn,                  SHCMD("") }, */
+	{ MODKEY,                       XK_x,          incrgaps,               {.i = -3 } },
+	/* { MODKEY|ShiftMask,             XK_x,          spawn,                  SHCMD("") }, */
+	{ MODKEY,                       XK_c,          spawn,                  {.v = (const char*[]){ TERMINAL, "-e", "profanity", NULL } } },
+	/* { MODKEY|ShiftMask,             XK_c,          spawn,                  SHCMD("") }, */
 	/* V is automatically bound above in STACKKEYS */
-	{ MODKEY,			XK_b,          togglebar,              {0} },
-	/* { MODKEY|ShiftMask,		XK_b,          spawn,                  SHCMD("") }, */
-	{ MODKEY,			XK_n,          spawn,                  {.v = (const char*[]){ TERMINAL, "-e", "nvim", "-c", "VimwikiIndex", NULL } } },
-	{ MODKEY|ShiftMask,		XK_n,          spawn,                  SHCMD(TERMINAL " -e newsboat ; pkill -RTMIN+6 dwmblocks") },
-	{ MODKEY,			XK_m,          spawn,                  {.v = (const char*[]){ TERMINAL, "-e", "ncmpcpp", NULL } } },
-	{ MODKEY|ShiftMask,		XK_m,          spawn,                  SHCMD("wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle; kill -44 $(pidof dwmblocks)") },
-	{ MODKEY,			XK_comma,      spawn,                  {.v = (const char*[]){ "mpc", "prev", NULL } } },
-	{ MODKEY|ShiftMask,		XK_comma,      spawn,                  {.v = (const char*[]){ "mpc", "seek", "0%", NULL } } },
-	{ MODKEY,			XK_period,     spawn,                  {.v = (const char*[]){ "mpc", "next", NULL } } },
-	{ MODKEY|ShiftMask,		XK_period,     spawn,                  {.v = (const char*[]){ "mpc", "repeat", NULL } } },
+	{ MODKEY,                       XK_b,          togglebar,              {0} },
+	/* { MODKEY|ShiftMask,             XK_b,          spawn,                  SHCMD("") }, */
+	{ MODKEY,                       XK_n,          spawn,                  {.v = (const char*[]){ TERMINAL, "-e", "nvim", "-c", "VimwikiIndex", NULL } } },
+	{ MODKEY|ShiftMask,             XK_n,          spawn,                  SHCMD(TERMINAL " -e newsboat ; pkill -RTMIN+6 dwmblocks") },
+	{ MODKEY,                       XK_m,          spawn,                  {.v = (const char*[]){ TERMINAL, "-e", "ncmpcpp", NULL } } },
+	{ MODKEY|ShiftMask,             XK_m,          spawn,                  SHCMD("wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle; kill -44 $(pidof dwmblocks)") },
+	{ MODKEY,                       XK_comma,      spawn,                  {.v = (const char*[]){ "mpc", "prev", NULL } } },
+	{ MODKEY|ShiftMask,             XK_comma,      spawn,                  {.v = (const char*[]){ "mpc", "seek", "0%", NULL } } },
+	{ MODKEY,                       XK_period,     spawn,                  {.v = (const char*[]){ "mpc", "next", NULL } } },
+	{ MODKEY|ShiftMask,             XK_period,     spawn,                  {.v = (const char*[]){ "mpc", "repeat", NULL } } },
 
-	{ MODKEY,			XK_Left,       focusmon,               {.i = -1 } },
-	{ MODKEY|ShiftMask,		XK_Left,       tagmon,                 {.i = -1 } },
-	{ MODKEY,			XK_Right,      focusmon,               {.i = +1 } },
-	{ MODKEY|ShiftMask,		XK_Right,      tagmon,                 {.i = +1 } },
+	{ MODKEY,                       XK_Left,       focusmon,               {.i = -1 } },
+	{ MODKEY|ShiftMask,             XK_Left,       tagmon,                 {.i = -1 } },
+	{ MODKEY,                       XK_Right,      focusmon,               {.i = +1 } },
+	{ MODKEY|ShiftMask,             XK_Right,      tagmon,                 {.i = +1 } },
 
-	{ MODKEY,			XK_Page_Up,    shiftview,              { .i = -1 } },
-	{ MODKEY|ShiftMask,		XK_Page_Up,    shifttag,               { .i = -1 } },
-	{ MODKEY,			XK_Page_Down,  shiftview,              { .i = +1 } },
-	{ MODKEY|ShiftMask,		XK_Page_Down,  shifttag,               { .i = +1 } },
-	{ MODKEY,			XK_Insert,     spawn,                  SHCMD("xdotool type $(grep -v '^#' ~/.local/share/larbs/snippets | dmenu -i -l 50 | cut -d' ' -f1)") },
+	{ MODKEY,                       XK_Page_Up,    shiftview,              { .i = -1 } },
+	{ MODKEY|ShiftMask,             XK_Page_Up,    shifttag,               { .i = -1 } },
+	{ MODKEY,                       XK_Page_Down,  shiftview,              { .i = +1 } },
+	{ MODKEY|ShiftMask,             XK_Page_Down,  shifttag,               { .i = +1 } },
+	{ MODKEY,                       XK_Insert,     spawn,                  SHCMD("xdotool type $(grep -v '^#' ~/.local/share/larbs/snippets | dmenu -i -l 50 | cut -d' ' -f1)") },
 
-	{ MODKEY,			XK_F1,         spawn,                  SHCMD("groff -mom /usr/local/share/dwm/larbs.mom -Tpdf | zathura -") },
-	{ MODKEY,			XK_F2,         spawn,                  {.v = (const char*[]){ "tutorialvids", NULL } } },
-	{ MODKEY,			XK_F3,         spawn,                  {.v = (const char*[]){ "displayselect", NULL } } },
-	{ MODKEY,			XK_F4,         spawn,                  SHCMD(TERMINAL " -e pulsemixer; kill -44 $(pidof dwmblocks)") },
-	{ MODKEY,			XK_F5,         xrdb,                   {.v = NULL } },
-	{ MODKEY,			XK_F6,         spawn,                  {.v = (const char*[]){ "torwrap", NULL } } },
-	{ MODKEY,			XK_F7,         spawn,                  {.v = (const char*[]){ "td-toggle", NULL } } },
-	{ MODKEY,			XK_F8,         spawn,                  {.v = (const char*[]){ "mailsync", NULL } } },
-	{ MODKEY,			XK_F9,         spawn,                  {.v = (const char*[]){ "mounter", NULL } } },
-	{ MODKEY,			XK_F10,        spawn,                  {.v = (const char*[]){ "unmounter", NULL } } },
-	{ MODKEY,			XK_F11,        spawn,                  SHCMD("mpv --untimed --no-cache --no-osc --no-input-default-bindings --profile=low-latency --input-conf=/dev/null --title=webcam $(ls /dev/video[0,2,4,6,8] | tail -n 1)") },
-	{ MODKEY,			XK_F12,        spawn,                  SHCMD("remaps") },
-	{ MODKEY,			XK_space,      zoom,                   {0} },
-	{ MODKEY|ShiftMask,		XK_space,      togglefloating,         {0} },
+	{ MODKEY,                       XK_F1,         spawn,                  SHCMD("groff -mom /usr/local/share/dwm/larbs.mom -Tpdf | zathura -") },
+	{ MODKEY,                       XK_F2,         spawn,                  {.v = (const char*[]){ "tutorialvids", NULL } } },
+	{ MODKEY,                       XK_F3,         spawn,                  {.v = (const char*[]){ "displayselect", NULL } } },
+	{ MODKEY,                       XK_F4,         spawn,                  SHCMD(TERMINAL " -e pulsemixer; kill -44 $(pidof dwmblocks)") },
+	{ MODKEY,                       XK_F5,         xrdb,                   {.v = NULL } },
+	{ MODKEY,                       XK_F6,         spawn,                  {.v = (const char*[]){ "torwrap", NULL } } },
+	{ MODKEY,                       XK_F7,         spawn,                  {.v = (const char*[]){ "td-toggle", NULL } } },
+	{ MODKEY,                       XK_F8,         spawn,                  {.v = (const char*[]){ "mailsync", NULL } } },
+	{ MODKEY,                       XK_F9,         spawn,                  {.v = (const char*[]){ "mounter", NULL } } },
+	{ MODKEY,                       XK_F10,        spawn,                  {.v = (const char*[]){ "unmounter", NULL } } },
+	{ MODKEY,                       XK_F11,        spawn,                  SHCMD("mpv --untimed --no-cache --no-osc --no-input-default-bindings --profile=low-latency --input-conf=/dev/null --title=webcam $(ls /dev/video[0,2,4,6,8] | tail -n 1)") },
+	{ MODKEY,                       XK_F12,        spawn,                  SHCMD("remaps") },
+	{ MODKEY,                       XK_space,      zoom,                   {0} },
+	{ MODKEY|ShiftMask,             XK_space,      togglefloating,         {0} },
 
-	{ 0,				XK_Print,      spawn,                  SHCMD("maim pic-full-$(date '+%y%m%d-%H%M-%S').png") },
-	{ ShiftMask,			XK_Print,      spawn,                  {.v = (const char*[]){ "maimpick", NULL } } },
-	{ MODKEY,			XK_Print,      spawn,		       {.v = (const char*[]){ "dmenurecord", NULL } } },
-	{ MODKEY|ShiftMask,		XK_Print,      spawn,                  {.v = (const char*[]){ "dmenurecord", "kill", NULL } } },
-	{ MODKEY,			XK_Delete,     spawn,                  {.v = (const char*[]){ "dmenurecord", "kill", NULL } } },
-	{ MODKEY,			XK_Scroll_Lock, spawn,                 SHCMD("killall screenkey || screenkey &") },
+	{ 0,                            XK_Print,      spawn,                  SHCMD("maim pic-full-$(date '+%y%m%d-%H%M-%S').png") },
+	{ ShiftMask,                    XK_Print,      spawn,                  {.v = (const char*[]){ "maimpick", NULL } } },
+	{ MODKEY,                       XK_Print,      spawn,                  {.v = (const char*[]){ "dmenurecord", NULL } } },
+	{ MODKEY|ShiftMask,             XK_Print,      spawn,                  {.v = (const char*[]){ "dmenurecord", "kill", NULL } } },
+	{ MODKEY,                       XK_Delete,     spawn,                  {.v = (const char*[]){ "dmenurecord", "kill", NULL } } },
+	{ MODKEY,                       XK_Scroll_Lock, spawn,                 SHCMD("killall screenkey || screenkey &") },
 
 	{ 0, XF86XK_AudioMute,                         spawn,                  SHCMD("wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle; kill -44 $(pidof dwmblocks)") },
 	{ 0, XF86XK_AudioRaiseVolume,                  spawn,                  SHCMD("wpctl set-volume @DEFAULT_AUDIO_SINK@ 0%- && wpctl set-volume @DEFAULT_AUDIO_SINK@ 3%+; kill -44 $(pidof dwmblocks)") },
@@ -272,7 +269,7 @@ static const Key keys[] = {
 	{ 0, XF86XK_AudioForward,                      spawn,                  {.v = (const char*[]){ "mpc", "seek", "+10", NULL } } },
 	{ 0, XF86XK_AudioMedia,                        spawn,                  {.v = (const char*[]){ TERMINAL, "-e", "ncmpcpp", NULL } } },
 	{ 0, XF86XK_AudioMicMute,                      spawn,                  SHCMD("pactl set-source-mute @DEFAULT_SOURCE@ toggle") },
-	/* { 0, XF86XK_PowerOff,                       spawn,                  {.v = (const char*[]){ "sysact", NULL } } }, */
+	/* { 0, XF86XK_PowerOff,                          spawn,                  {.v = (const char*[]){ "sysact", NULL } } }, */
 	{ 0, XF86XK_Calculator,                        spawn,                  {.v = (const char*[]){ TERMINAL, "-e", "bc", "-l", NULL } } },
 	{ 0, XF86XK_Sleep,                             spawn,                  {.v = (const char*[]){ "sudo", "-A", "zzz", NULL } } },
 	{ 0, XF86XK_WWW,                               spawn,                  {.v = (const char*[]){ BROWSER, NULL } } },
@@ -281,7 +278,7 @@ static const Key keys[] = {
 	{ 0, XF86XK_TaskPane,                          spawn,                  {.v = (const char*[]){ TERMINAL, "-e", "htop", NULL } } },
 	{ 0, XF86XK_Mail,                              spawn,                  SHCMD(TERMINAL " -e neomutt ; pkill -RTMIN+12 dwmblocks") },
 	{ 0, XF86XK_MyComputer,                        spawn,                  {.v = (const char*[]){ TERMINAL, "-e",  "lfub",  "/", NULL } } },
-	/* { 0, XF86XK_Battery,                        spawn,                  SHCMD("") }, */
+	/* { 0, XF86XK_Battery,                           spawn,                  SHCMD("") }, */
 	{ 0, XF86XK_Launch1,                           spawn,                  {.v = (const char*[]){ "xset", "dpms", "force", "off", NULL } } },
 	{ 0, XF86XK_TouchpadToggle,                    spawn,                  SHCMD("(synclient | grep 'TouchpadOff.*1' && synclient TouchpadOff=0) || synclient TouchpadOff=1") },
 	{ 0, XF86XK_TouchpadOff,                       spawn,                  {.v = (const char*[]){ "synclient", "TouchpadOff=1", NULL } } },
@@ -289,21 +286,21 @@ static const Key keys[] = {
 	{ 0, XF86XK_MonBrightnessUp,                   spawn,                  {.v = (const char*[]){ "xbacklight", "-inc", "15", NULL } } },
 	{ 0, XF86XK_MonBrightnessDown,                 spawn,                  {.v = (const char*[]){ "xbacklight", "-dec", "15", NULL } } },
 
-	/* { MODKEY|Mod4Mask,           XK_h,          incrgaps,               {.i = +1 } }, */
-	/* { MODKEY|Mod4Mask,           XK_l,          incrgaps,               {.i = -1 } }, */
-	/* { MODKEY|Mod4Mask|ShiftMask, XK_h,          incrogaps,              {.i = +1 } }, */
-	/* { MODKEY|Mod4Mask|ShiftMask, XK_l,          incrogaps,              {.i = -1 } }, */
-	/* { MODKEY|Mod4Mask|ControlMask, XK_h,        incrigaps,              {.i = +1 } }, */
-	/* { MODKEY|Mod4Mask|ControlMask, XK_l,        incrigaps,              {.i = -1 } }, */
-	/* { MODKEY|Mod4Mask|ShiftMask, XK_0,          defaultgaps,            {0} }, */
-	/* { MODKEY,                    XK_y,          incrihgaps,             {.i = +1 } }, */
-	/* { MODKEY,                    XK_o,          incrihgaps,             {.i = -1 } }, */
-	/* { MODKEY|ControlMask,        XK_y,          incrivgaps,             {.i = +1 } }, */
-	/* { MODKEY|ControlMask,        XK_o,          incrivgaps,             {.i = -1 } }, */
-	/* { MODKEY|Mod4Mask,           XK_y,          incrohgaps,             {.i = +1 } }, */
-	/* { MODKEY|Mod4Mask,           XK_o,          incrohgaps,             {.i = -1 } }, */
-	/* { MODKEY|ShiftMask,          XK_y,          incrovgaps,             {.i = +1 } }, */
-	/* { MODKEY|ShiftMask,          XK_o,          incrovgaps,             {.i = -1 } }, */
+	/* { MODKEY|Mod4Mask,              XK_h,          incrgaps,               {.i = +1 } }, */
+	/* { MODKEY|Mod4Mask,              XK_l,          incrgaps,               {.i = -1 } }, */
+	/* { MODKEY|Mod4Mask|ShiftMask,    XK_h,          incrogaps,              {.i = +1 } }, */
+	/* { MODKEY|Mod4Mask|ShiftMask,    XK_l,          incrogaps,              {.i = -1 } }, */
+	/* { MODKEY|Mod4Mask|ControlMask,  XK_h,          incrigaps,              {.i = +1 } }, */
+	/* { MODKEY|Mod4Mask|ControlMask,  XK_l,          incrigaps,              {.i = -1 } }, */
+	/* { MODKEY|Mod4Mask|ShiftMask,    XK_0,          defaultgaps,            {0} }, */
+	/* { MODKEY,                       XK_y,          incrihgaps,             {.i = +1 } }, */
+	/* { MODKEY,                       XK_o,          incrihgaps,             {.i = -1 } }, */
+	/* { MODKEY|ControlMask,           XK_y,          incrivgaps,             {.i = +1 } }, */
+	/* { MODKEY|ControlMask,           XK_o,          incrivgaps,             {.i = -1 } }, */
+	/* { MODKEY|Mod4Mask,              XK_y,          incrohgaps,             {.i = +1 } }, */
+	/* { MODKEY|Mod4Mask,              XK_o,          incrohgaps,             {.i = -1 } }, */
+	/* { MODKEY|ShiftMask,             XK_y,          incrovgaps,             {.i = +1 } }, */
+	/* { MODKEY|ShiftMask,             XK_o,          incrovgaps,             {.i = -1 } }, */
 
 };
 
@@ -324,13 +321,13 @@ static const Button buttons[] = {
 	{ ClkClientWin,         MODKEY,              Button1,        movemouse,      {0} },
 	{ ClkClientWin,         MODKEY,              Button2,        defaultgaps,    {0} },
 	{ ClkClientWin,         MODKEY,              Button3,        resizemouse,    {0} },
-	{ ClkClientWin,		MODKEY,		     Button4,	     incrgaps,       {.i = +1} },
-	{ ClkClientWin,		MODKEY,		     Button5,	     incrgaps,       {.i = -1} },
+	{ ClkClientWin,         MODKEY,              Button4,        incrgaps,       {.i = +1} },
+	{ ClkClientWin,         MODKEY,              Button5,        incrgaps,       {.i = -1} },
 	{ ClkTagBar,            0,                   Button1,        view,           {0} },
 	{ ClkTagBar,            0,                   Button3,        toggleview,     {0} },
 	{ ClkTagBar,            MODKEY,              Button1,        tag,            {0} },
 	{ ClkTagBar,            MODKEY,              Button3,        toggletag,      {0} },
-	{ ClkTagBar,		0,		     Button4,	     shiftview,      {.i = -1} },
-	{ ClkTagBar,		0,		     Button5,	     shiftview,      {.i = 1} },
-	{ ClkRootWin,		0,		     Button2,	     togglebar,      {0} },
+	{ ClkTagBar,            0,                   Button4,        shiftview,      {.i = -1} },
+	{ ClkTagBar,            0,                   Button5,        shiftview,      {.i = 1} },
+	{ ClkRootWin,           0,                   Button2,        togglebar,      {0} },
 };

--- a/dwm.c
+++ b/dwm.c
@@ -246,7 +246,7 @@ static void seturgent(Client *c, int urg);
 static void showhide(Client *c);
 static void sigchld(int unused);
 #ifndef __OpenBSD__
-static int getdwmblockspid();
+static int getdwmblockspid(void);
 static void sigdwmblocks(const Arg *arg);
 #endif
 static void sighup(int unused);
@@ -1045,7 +1045,7 @@ getatomprop(Client *c, Atom prop)
 
 #ifndef __OpenBSD__
 int
-getdwmblockspid()
+getdwmblockspid(void)
 {
 	char buf[16];
 	FILE *fp = popen("pidof -s dwmblocks", "r");
@@ -2191,7 +2191,7 @@ updatebarpos(Monitor *m)
 }
 
 void
-updateclientlist()
+updateclientlist(void)
 {
 	Client *c;
 	Monitor *m;


### PR DESCRIPTION
In my previous commit, the formatting seemed impeccable within Vim, yet exhibited misalignment in Neovim under the LazyVim configuration, impacting numerous lines of code. Consequently, I've implemented a uniform approach to the application of spaces and tabs throughout the codebase, guaranteeing consistent formatting. Regarding the modifications to dwm.c, I've solely focused on resolving the Clang warnings.